### PR TITLE
Add backlinks feature to surface inbound note connections

### DIFF
--- a/docs/backlinks-prd.md
+++ b/docs/backlinks-prd.md
@@ -1,0 +1,178 @@
+# Backlinks in Thought.Haus — Product Requirements Document
+
+## Problem Statement
+
+Thought.Haus already supports forward-linking between notes with `[[YYYYMMDDTHHMMSS]]` syntax. A user can type `[[` to link to another note, and clicking that link navigates to the target. But the relationship is one-directional: if Note A links to Note B, Note B has no awareness of this connection.
+
+This means a note can be referenced from five other places and the author would never know. The connections between ideas exist in the user's head but are invisible in the tool. Backlinks surface these inbound connections without requiring users to manually maintain them.
+
+## Landscape Analysis
+
+### What works across apps
+
+Every major note-linking tool (Obsidian, Roam, Logseq, Notion, Bear) implements backlinks differently, but the patterns that survive real usage are consistent:
+
+1. **A simple list of linking notes is sufficient.** Obsidian's backlinks panel, Roam's linked references, and Logseq's references all boil down to the same thing: a list of notes that link to the current note. Users glance at it, occasionally click through, and move on. The list itself is the feature.
+
+2. **Context matters, but not much.** Obsidian shows the paragraph surrounding each backlink. Roam shows the block. In practice, most users just read the note title, recognize the connection, and click if they want to revisit it. A line or two of surrounding context helps with disambiguation when multiple notes share similar titles, but walls of preview text go unread.
+
+3. **Always-visible beats hidden.** Obsidian offers both a sidebar panel and an in-note section. Users overwhelmingly prefer the in-note section because it's discoverable without configuration. Notion's backlinks (a collapsed "N backlinks" line at the top of a page) succeed precisely because they're present without being loud.
+
+4. **Graph views are toys.** Every PKM app ships a graph view. Users play with it for ten minutes, screenshot it for Twitter, and never open it again. It provides almost zero utility for actual note-taking work. The network is too dense to read, the layout is arbitrary, and there's no action you can take from it that you can't take faster from a backlinks list.
+
+5. **"Unlinked mentions" are noise.** Obsidian and Roam show text matches that *could* be links but aren't. In practice, this generates false positives and users either disable it or learn to ignore it. It's a feature for completionists, not writers.
+
+### What the minimalist apps teach us
+
+Bear added backlinks years after launch. Their implementation is instructive: a small, collapsible section at the bottom of a note showing linked note titles. No context snippets. No graph. No unlinked mentions. It works because it's quiet. Apple Notes still has no backlinks at all. iA Writer supports wiki-links for navigation but has no backlink surfacing — and users don't complain much, because the core value is writing, not knowledge management.
+
+The lesson: backlinks are most valuable when they're ambient information, not a primary interface. They should answer the question "what links here?" without demanding attention.
+
+## Design Principles for Thought.Haus
+
+1. **No new panels, sidebars, or views.** The three-column layout (NavSidebar | NotesList | Editor) is the product. Backlinks live inside the editor view, not beside it.
+
+2. **Present when relevant, invisible when not.** If a note has zero backlinks, show nothing. If it has backlinks, show them quietly below the editor content.
+
+3. **Titles are enough.** The backlink list shows note titles. Users can click to navigate. No paragraph-level context, no block embeds, no search result highlighting.
+
+4. **Computed, not stored.** Backlinks are derived from the existing `[[noteId]]` link syntax already in note content. No new file format, no sidecar files, no database. The index lives in memory and is rebuilt from what already exists.
+
+5. **No graph view.** Not now, not on the roadmap. A backlinks list provides the same information in a more actionable format.
+
+6. **No unlinked mentions.** Text matching without explicit links is a search problem, and Thought.Haus already has search. Conflating the two creates noise.
+
+## Feature Specification
+
+### Backlink Index
+
+A reactive, in-memory index that maps each note ID to the set of note IDs that link to it.
+
+**Data structure:**
+
+```
+Map<string, Set<string>>   // targetNoteId → Set<sourceNoteId>
+```
+
+**When it's built:**
+- During the initial directory scan (alongside the search index build), the body of each note is already read. Parse outgoing `[[noteId]]` references from each note body using the existing `parseNoteLinks()` function and populate the backlink map.
+
+**When it's updated:**
+- On note save: re-parse the saved note's body, diff against its previous outgoing links, and update the backlink map entries for any added or removed targets.
+- On note delete: remove all outgoing link entries from the deleted note.
+- On file watcher update: when external changes are detected and a note's content changes, re-parse and update.
+
+**Reactive surface:**
+- Export a function `getBacklinks(noteId: string): Note[]` that returns the notes linking to the given note, sorted by creation date (newest first).
+- Wrap it so the editor view can reactively display backlinks for the currently selected note. A Preact Signal (`backlinkIndex`) enables this — when the map updates, any computed that reads from it will re-render.
+
+**Location:** New module at `packages/app/src/notes/backlink-index.ts`. This keeps backlink logic out of the note store (which manages CRUD) and out of the search engine (which manages full-text search). Backlinks are a relationship index, which is a distinct concern.
+
+### Editor UI — Backlinks Section
+
+A collapsible section rendered below the TipTap editor content and above the status bar in `EditorView`.
+
+**Layout:**
+
+```
+┌─────────────────────────────────────────────┐
+│  ★  Meeting Notes                           │
+│  [ work ] [ meetings ]  + tag  March 22     │
+│─────────────────────────────────────────────│
+│                                             │
+│  (TipTap editor content)                    │
+│                                             │
+│  ...                                        │
+│                                             │
+│─────────────────────────────────────────────│
+│  ↗ 3 backlinks                    ▾         │  ← new: backlinks header
+│                                             │
+│    Project Alpha Overview                   │  ← clickable note title
+│    Weekly Review 2024-03-22                 │
+│    Research: Distributed Systems            │
+│                                             │
+│─────────────────────────────────────────────│
+│  423 words                        Saved     │
+└─────────────────────────────────────────────┘
+```
+
+**Behavior:**
+
+- **Visibility:** Only rendered when the current note has at least one backlink. Zero backlinks = no section, no empty state, no placeholder.
+- **Header:** Shows the count (e.g., "3 backlinks") with a small toggle chevron. Clicking the header collapses/expands the list.
+- **Default state:** Expanded. The collapsed/expanded preference is persisted per-session (not per-note) using a signal, similar to how `sidebarCollapsed` works. Most users will leave it expanded once they discover it.
+- **List items:** Each backlink is a single line showing the note title. Clicking navigates to that note (sets `selectedNoteId`). Hover shows the same subtle highlight used elsewhere in the app.
+- **Scroll behavior:** The backlinks section is inside the scrollable editor body area, below the editor content. It scrolls naturally with the document. It does not take away from the editor's vertical space for short documents — the editor content has a `min-height` and the backlinks appear after it.
+- **Separator:** A subtle top border separates the backlinks section from the editor content, using the same `--color-border` used in the status bar.
+
+**Styling:**
+
+- Matches the existing metadata styling conventions: `0.8125rem` font size, `var(--color-text-secondary)` color, same horizontal padding as the editor body (`3rem` desktop, `1rem` mobile).
+- Note titles in the list use `var(--color-accent)` on hover, matching the note-link styling in the editor.
+- The toggle chevron is a small Lucide icon (`ChevronDown` / `ChevronRight`), 14px, secondary color.
+- No background color, no cards, no borders around individual items. Just a clean list.
+
+### Integration Points
+
+**`packages/app/src/notes/backlink-index.ts` (new file)**
+- `backlinkIndex` signal: `Signal<Map<string, Set<string>>>`
+- `buildBacklinkIndex(notes, readBody)`: called during scan, builds the full index
+- `updateNoteLinks(noteId, body)`: called on save, updates outgoing links for one note
+- `removeNoteLinks(noteId)`: called on delete
+- `getBacklinks(noteId)`: returns `Note[]` of notes linking to the given ID
+
+**`packages/app/src/storage/scan.ts`**
+- After scanning notes and building the search index, call `buildBacklinkIndex()` using the note bodies already read during scan. No additional file reads needed.
+
+**`packages/app/src/ui/editor-view.tsx`**
+- Import `getBacklinks` and render the backlinks section below the editor body div.
+- New component `BacklinksSection` (either inline or a small separate component in the same file or a new `backlinks-section.tsx`).
+
+**`packages/app/src/notes/note-actions.ts`**
+- After saving a note: call `updateNoteLinks(noteId, body)`.
+- After deleting a note: call `removeNoteLinks(noteId)`.
+
+**`packages/app/src/storage/file-watcher.ts`**
+- When an external change updates a note's content: call `updateNoteLinks()` with the new body.
+
+### What This Feature Does NOT Include
+
+- **Graph view:** No visual network diagram. Not planned.
+- **Unlinked mentions:** No fuzzy text matching for potential links. Search already handles this.
+- **Backlink count in NotesList:** The sidebar note items do not show a backlink count badge. This would add visual noise to every note item for marginal benefit.
+- **Outgoing links section:** No "links from this note" panel. The user can see outgoing links by reading their own note. Showing them again in a list is redundant.
+- **Backlink persistence to disk:** The index is computed at load time from existing note content. No `.thoughthouse/backlinks.json` or similar file. This keeps the system stateless and avoids sync issues.
+- **Two-hop connections:** No "notes that link to notes that link to this note." This is complexity that serves academics writing dissertations, not day-to-day note-takers.
+
+## Technical Notes
+
+### Performance
+
+The backlink index is a lightweight `Map<string, Set<string>>`. For a typical vault of 1,000 notes with an average of 3 links per note, this is 3,000 entries — trivial in memory and sub-millisecond to query. Parsing `[[noteId]]` uses the existing `NOTE_LINK_RE` regex which is already battle-tested. The full rebuild during scan adds negligible time since the note bodies are already being read for the search index.
+
+Incremental updates on save are O(L) where L is the number of outgoing links in the saved note (typically < 10). There is no expensive re-indexing.
+
+### Consistency with existing patterns
+
+- **Signals for reactivity:** Follows the same pattern as `notesMap`, `tagCounts`, `favoriteIds`. A signal holds the map; consumers react to changes.
+- **CSS Modules:** The backlinks section uses a CSS module (either the existing `editor-view.module.css` or a new `backlinks-section.module.css`).
+- **No new dependencies:** Uses existing `parseNoteLinks()`, `getNote()`, and `notesMap`. No new libraries.
+- **Mobile support:** The backlinks section renders identically on mobile, just with the narrower padding. No special mobile treatment needed since it's part of the scrollable editor body.
+
+### Edge cases
+
+- **Circular links:** Note A links to Note B and vice versa. Both show the other in their backlinks. This is correct and expected behavior.
+- **Self-links:** A note linking to itself (`[[ownId]]`) should not appear in its own backlinks list.
+- **Broken links:** If Note A contains `[[nonexistent]]`, this does not generate a backlink entry because the target note doesn't exist. If the target is later created, it will pick up the backlink on the next scan or when Note A is re-saved.
+- **Non-timestamp notes:** Plain `.md` files without timestamp IDs are supported as both source and target of links, consistent with existing note-link behavior.
+- **Deleted source notes:** When a note is deleted, `removeNoteLinks()` cleans up its entries from the backlink index. The target note's backlinks section updates reactively.
+
+## Success Criteria
+
+- Opening a note that is linked from other notes shows a backlinks section with correct, clickable titles.
+- Opening a note with no inbound links shows no backlinks section.
+- Creating a new link to a note and saving causes the target note's backlinks to update.
+- Deleting a note removes it from all backlink lists.
+- The backlinks section is visually quiet and consistent with the existing Thought.Haus aesthetic.
+- No new panels, sidebars, modals, or settings are introduced.
+- Performance is imperceptible — no visible delay on scan or save.

--- a/packages/app/src/notes/backlink-index.test.ts
+++ b/packages/app/src/notes/backlink-index.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  backlinkIndex,
+  buildBacklinkIndex,
+  updateNoteLinks,
+  removeNoteLinks,
+  getBacklinks,
+  clearBacklinks,
+} from "./backlink-index.ts";
+import { setNotes, notesMap } from "./note-store.ts";
+import type { Note } from "@thought-haus/core";
+
+function makeNote(overrides: Partial<Note> & { id: string }): Note {
+  return {
+    title: "Test Note",
+    tags: [],
+    properties: {},
+    filename: `${overrides.id}--test-note.md`,
+    lastModified: Date.now(),
+    size: 100,
+    isTimestampFormat: true,
+    createdAt: new Date("2024-03-22T13:18:56"),
+    ...overrides,
+  };
+}
+
+const NOTE_A = "20240101T000000";
+const NOTE_B = "20240202T120000";
+const NOTE_C = "20240303T180000";
+
+beforeEach(() => {
+  clearBacklinks();
+  notesMap.value = new Map();
+});
+
+describe("buildBacklinkIndex", () => {
+  it("builds index from note bodies with links", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+      makeNote({ id: NOTE_C, title: "Note C" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `See [[${NOTE_B}]] for details` },
+      { id: NOTE_B, body: `Related to [[${NOTE_C}]]` },
+      { id: NOTE_C, body: "No links here" },
+    ]);
+
+    // NOTE_B is linked by NOTE_A
+    expect(backlinkIndex.value.get(NOTE_B)?.has(NOTE_A)).toBe(true);
+    // NOTE_C is linked by NOTE_B
+    expect(backlinkIndex.value.get(NOTE_C)?.has(NOTE_B)).toBe(true);
+    // NOTE_A is not linked by anyone
+    expect(backlinkIndex.value.has(NOTE_A)).toBe(false);
+  });
+
+  it("handles multiple links in one note", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+      makeNote({ id: NOTE_C, title: "Note C" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `Links to [[${NOTE_B}]] and [[${NOTE_C}]]` },
+      { id: NOTE_B, body: "" },
+      { id: NOTE_C, body: "" },
+    ]);
+
+    expect(backlinkIndex.value.get(NOTE_B)?.has(NOTE_A)).toBe(true);
+    expect(backlinkIndex.value.get(NOTE_C)?.has(NOTE_A)).toBe(true);
+  });
+
+  it("excludes self-links", () => {
+    setNotes([makeNote({ id: NOTE_A, title: "Note A" })]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `Self ref [[${NOTE_A}]]` },
+    ]);
+
+    expect(backlinkIndex.value.has(NOTE_A)).toBe(false);
+  });
+
+  it("handles circular links", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `See [[${NOTE_B}]]` },
+      { id: NOTE_B, body: `See [[${NOTE_A}]]` },
+    ]);
+
+    expect(backlinkIndex.value.get(NOTE_A)?.has(NOTE_B)).toBe(true);
+    expect(backlinkIndex.value.get(NOTE_B)?.has(NOTE_A)).toBe(true);
+  });
+
+  it("handles empty note bodies", () => {
+    buildBacklinkIndex([
+      { id: NOTE_A, body: "" },
+      { id: NOTE_B, body: "" },
+    ]);
+
+    expect(backlinkIndex.value.size).toBe(0);
+  });
+});
+
+describe("updateNoteLinks", () => {
+  it("adds new backlinks when a note is saved with links", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: "" },
+      { id: NOTE_B, body: "" },
+    ]);
+
+    updateNoteLinks(NOTE_A, `Now links to [[${NOTE_B}]]`);
+
+    expect(backlinkIndex.value.get(NOTE_B)?.has(NOTE_A)).toBe(true);
+  });
+
+  it("removes backlinks when a link is removed from a note", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `Link to [[${NOTE_B}]]` },
+      { id: NOTE_B, body: "" },
+    ]);
+
+    expect(backlinkIndex.value.get(NOTE_B)?.has(NOTE_A)).toBe(true);
+
+    // Save NOTE_A without the link
+    updateNoteLinks(NOTE_A, "No more links");
+
+    expect(backlinkIndex.value.has(NOTE_B)).toBe(false);
+  });
+
+  it("handles link target changes", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+      makeNote({ id: NOTE_C, title: "Note C" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `Link to [[${NOTE_B}]]` },
+      { id: NOTE_B, body: "" },
+      { id: NOTE_C, body: "" },
+    ]);
+
+    // Change link from B to C
+    updateNoteLinks(NOTE_A, `Now links to [[${NOTE_C}]]`);
+
+    expect(backlinkIndex.value.has(NOTE_B)).toBe(false);
+    expect(backlinkIndex.value.get(NOTE_C)?.has(NOTE_A)).toBe(true);
+  });
+
+  it("does not update signal when no changes occur", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `Link to [[${NOTE_B}]]` },
+      { id: NOTE_B, body: "" },
+    ]);
+
+    const prevIndex = backlinkIndex.value;
+    updateNoteLinks(NOTE_A, `Still links to [[${NOTE_B}]]`);
+
+    // Signal value should be the same reference (no update)
+    expect(backlinkIndex.value).toBe(prevIndex);
+  });
+
+  it("skips self-links on update", () => {
+    setNotes([makeNote({ id: NOTE_A, title: "Note A" })]);
+
+    buildBacklinkIndex([{ id: NOTE_A, body: "" }]);
+
+    updateNoteLinks(NOTE_A, `Self [[${NOTE_A}]]`);
+
+    expect(backlinkIndex.value.has(NOTE_A)).toBe(false);
+  });
+});
+
+describe("removeNoteLinks", () => {
+  it("removes note as source from all targets", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+      makeNote({ id: NOTE_C, title: "Note C" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `[[${NOTE_B}]] and [[${NOTE_C}]]` },
+      { id: NOTE_B, body: "" },
+      { id: NOTE_C, body: "" },
+    ]);
+
+    removeNoteLinks(NOTE_A);
+
+    expect(backlinkIndex.value.has(NOTE_B)).toBe(false);
+    expect(backlinkIndex.value.has(NOTE_C)).toBe(false);
+  });
+
+  it("removes note as target (backlinks to deleted note)", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `Link to [[${NOTE_B}]]` },
+      { id: NOTE_B, body: "" },
+    ]);
+
+    // Delete NOTE_B — its backlinks entry should be removed
+    removeNoteLinks(NOTE_B);
+
+    expect(backlinkIndex.value.has(NOTE_B)).toBe(false);
+  });
+
+  it("preserves other notes' backlinks when one is removed", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+      makeNote({ id: NOTE_C, title: "Note C" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `[[${NOTE_C}]]` },
+      { id: NOTE_B, body: `[[${NOTE_C}]]` },
+      { id: NOTE_C, body: "" },
+    ]);
+
+    // Both A and B link to C
+    expect(backlinkIndex.value.get(NOTE_C)?.size).toBe(2);
+
+    // Remove A's links
+    removeNoteLinks(NOTE_A);
+
+    // C should still have B as a backlink
+    expect(backlinkIndex.value.get(NOTE_C)?.has(NOTE_B)).toBe(true);
+    expect(backlinkIndex.value.get(NOTE_C)?.size).toBe(1);
+  });
+
+  it("handles removing a note with no links gracefully", () => {
+    buildBacklinkIndex([
+      { id: NOTE_A, body: "" },
+    ]);
+
+    // Should not throw
+    removeNoteLinks(NOTE_A);
+    expect(backlinkIndex.value.size).toBe(0);
+  });
+});
+
+describe("getBacklinks", () => {
+  it("returns notes linking to the given ID", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A", createdAt: new Date("2024-01-01") }),
+      makeNote({ id: NOTE_B, title: "Note B", createdAt: new Date("2024-02-01") }),
+      makeNote({ id: NOTE_C, title: "Note C" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `[[${NOTE_C}]]` },
+      { id: NOTE_B, body: `[[${NOTE_C}]]` },
+      { id: NOTE_C, body: "" },
+    ]);
+
+    const backlinks = getBacklinks(NOTE_C);
+    expect(backlinks).toHaveLength(2);
+    expect(backlinks.map((n) => n.id)).toContain(NOTE_A);
+    expect(backlinks.map((n) => n.id)).toContain(NOTE_B);
+  });
+
+  it("returns empty array for notes with no backlinks", () => {
+    setNotes([makeNote({ id: NOTE_A, title: "Note A" })]);
+    buildBacklinkIndex([{ id: NOTE_A, body: "" }]);
+
+    expect(getBacklinks(NOTE_A)).toHaveLength(0);
+  });
+
+  it("sorts by creation date newest first", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Older", createdAt: new Date("2024-01-01") }),
+      makeNote({ id: NOTE_B, title: "Newer", createdAt: new Date("2024-06-01") }),
+      makeNote({ id: NOTE_C, title: "Target" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `[[${NOTE_C}]]` },
+      { id: NOTE_B, body: `[[${NOTE_C}]]` },
+      { id: NOTE_C, body: "" },
+    ]);
+
+    const backlinks = getBacklinks(NOTE_C);
+    expect(backlinks[0].id).toBe(NOTE_B); // Newer first
+    expect(backlinks[1].id).toBe(NOTE_A);
+  });
+
+  it("excludes source notes that no longer exist in store", () => {
+    setNotes([
+      makeNote({ id: NOTE_A, title: "Note A" }),
+      makeNote({ id: NOTE_B, title: "Note B" }),
+      makeNote({ id: NOTE_C, title: "Note C" }),
+    ]);
+
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `[[${NOTE_C}]]` },
+      { id: NOTE_B, body: `[[${NOTE_C}]]` },
+      { id: NOTE_C, body: "" },
+    ]);
+
+    // Remove NOTE_A from the store (simulating deletion without cleanup)
+    const map = new Map(notesMap.value);
+    map.delete(NOTE_A);
+    notesMap.value = map;
+
+    const backlinks = getBacklinks(NOTE_C);
+    expect(backlinks).toHaveLength(1);
+    expect(backlinks[0].id).toBe(NOTE_B);
+  });
+
+  it("returns empty array for unknown note ID", () => {
+    expect(getBacklinks("nonexistent")).toHaveLength(0);
+  });
+});
+
+describe("clearBacklinks", () => {
+  it("clears the entire index", () => {
+    buildBacklinkIndex([
+      { id: NOTE_A, body: `[[${NOTE_B}]]` },
+      { id: NOTE_B, body: "" },
+    ]);
+
+    expect(backlinkIndex.value.size).toBeGreaterThan(0);
+
+    clearBacklinks();
+
+    expect(backlinkIndex.value.size).toBe(0);
+  });
+});

--- a/packages/app/src/notes/backlink-index.ts
+++ b/packages/app/src/notes/backlink-index.ts
@@ -1,0 +1,164 @@
+import { signal } from "@preact/signals";
+import { parseNoteLinks } from "../editor/note-links.ts";
+import { getNote } from "./note-store.ts";
+import type { Note } from "@thought-haus/core";
+
+/**
+ * Reactive backlink index: targetNoteId → Set<sourceNoteId>.
+ * Updated incrementally on note save/delete and rebuilt on scan.
+ */
+export const backlinkIndex = signal<Map<string, Set<string>>>(new Map());
+
+/**
+ * Track outgoing links per note so we can diff on update.
+ * sourceNoteId → Set<targetNoteId>
+ */
+const outgoingLinks = new Map<string, Set<string>>();
+
+/** Build the full backlink index from note bodies read during scan. */
+export function buildBacklinkIndex(
+  docs: { id: string; body: string }[],
+): void {
+  const index = new Map<string, Set<string>>();
+  outgoingLinks.clear();
+
+  for (const doc of docs) {
+    const links = parseNoteLinks(doc.body);
+    const targets = new Set<string>();
+
+    for (const link of links) {
+      // Skip self-links
+      if (link.id === doc.id) continue;
+      targets.add(link.id);
+
+      let sources = index.get(link.id);
+      if (!sources) {
+        sources = new Set();
+        index.set(link.id, sources);
+      }
+      sources.add(doc.id);
+    }
+
+    outgoingLinks.set(doc.id, targets);
+  }
+
+  backlinkIndex.value = index;
+}
+
+/** Update the backlink index when a single note is saved. */
+export function updateNoteLinks(noteId: string, body: string): void {
+  const links = parseNoteLinks(body);
+  const newTargets = new Set<string>();
+  for (const link of links) {
+    if (link.id !== noteId) {
+      newTargets.add(link.id);
+    }
+  }
+
+  const oldTargets = outgoingLinks.get(noteId) ?? new Set();
+
+  // Find added and removed targets
+  const added = new Set<string>();
+  const removed = new Set<string>();
+
+  for (const target of newTargets) {
+    if (!oldTargets.has(target)) added.add(target);
+  }
+  for (const target of oldTargets) {
+    if (!newTargets.has(target)) removed.add(target);
+  }
+
+  // No changes — skip signal update
+  if (added.size === 0 && removed.size === 0) return;
+
+  const index = new Map(backlinkIndex.value);
+
+  for (const target of added) {
+    let sources = index.get(target);
+    if (!sources) {
+      sources = new Set();
+      index.set(target, sources);
+    } else {
+      sources = new Set(sources);
+      index.set(target, sources);
+    }
+    sources.add(noteId);
+  }
+
+  for (const target of removed) {
+    const sources = index.get(target);
+    if (sources) {
+      const newSources = new Set(sources);
+      newSources.delete(noteId);
+      if (newSources.size === 0) {
+        index.delete(target);
+      } else {
+        index.set(target, newSources);
+      }
+    }
+  }
+
+  outgoingLinks.set(noteId, newTargets);
+  backlinkIndex.value = index;
+}
+
+/** Remove all link entries for a deleted note. */
+export function removeNoteLinks(noteId: string): void {
+  const targets = outgoingLinks.get(noteId);
+  if (!targets || targets.size === 0) {
+    outgoingLinks.delete(noteId);
+
+    // Also remove any entries where this note is a target
+    if (backlinkIndex.value.has(noteId)) {
+      const index = new Map(backlinkIndex.value);
+      index.delete(noteId);
+      backlinkIndex.value = index;
+    }
+    return;
+  }
+
+  const index = new Map(backlinkIndex.value);
+
+  // Remove this note as a source from all its targets
+  for (const target of targets) {
+    const sources = index.get(target);
+    if (sources) {
+      const newSources = new Set(sources);
+      newSources.delete(noteId);
+      if (newSources.size === 0) {
+        index.delete(target);
+      } else {
+        index.set(target, newSources);
+      }
+    }
+  }
+
+  // Remove this note as a target (other notes linking to it are now linking to a deleted note)
+  index.delete(noteId);
+
+  outgoingLinks.delete(noteId);
+  backlinkIndex.value = index;
+}
+
+/** Get notes that link to the given note, sorted by creation date (newest first). */
+export function getBacklinks(noteId: string): Note[] {
+  const sources = backlinkIndex.value.get(noteId);
+  if (!sources || sources.size === 0) return [];
+
+  const notes: Note[] = [];
+  for (const sourceId of sources) {
+    const note = getNote(sourceId);
+    // Only include notes that still exist in the store
+    if (note) notes.push(note);
+  }
+
+  // Sort newest first by creation date
+  notes.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  return notes;
+}
+
+/** Clear the backlink index (e.g. on disconnect). */
+export function clearBacklinks(): void {
+  outgoingLinks.clear();
+  backlinkIndex.value = new Map();
+}

--- a/packages/app/src/notes/note-actions.ts
+++ b/packages/app/src/notes/note-actions.ts
@@ -8,6 +8,7 @@ import {
 } from "../search/search-engine.ts";
 import { deleteNoteAttachments } from "../attachments/attachment-service.ts";
 import { removeFavorite } from "../favorites/favorite-store.ts";
+import { removeNoteLinks } from "./backlink-index.ts";
 import type { Note } from "@thought-haus/core";
 
 const WELCOME_BODY = `Welcome to Thought.Haus! This is your first note.
@@ -78,6 +79,7 @@ export async function deleteNote(id: string): Promise<boolean> {
     removeNote(id);
     removeFromIndex(id);
     removeFavorite(id);
+    removeNoteLinks(id);
     if (selectedNoteId.value === id) {
       selectedNoteId.value = null;
     }

--- a/packages/app/src/storage/file-watcher.ts
+++ b/packages/app/src/storage/file-watcher.ts
@@ -9,6 +9,7 @@ import {
   updateInIndex,
 } from "../search/search-engine.ts";
 import { removeFavorite } from "../favorites/favorite-store.ts";
+import { updateNoteLinks, removeNoteLinks } from "../notes/backlink-index.ts";
 
 const POLL_INTERVAL = 7000; // 7 seconds
 
@@ -70,12 +71,14 @@ export async function applyChanges(
           body,
           lastModified: change.note.lastModified,
         });
+        updateNoteLinks(change.note.id, body);
         break;
       }
       case "deleted": {
         removeNote(change.note.id);
         removeFromIndex(change.note.id);
         removeFavorite(change.note.id);
+        removeNoteLinks(change.note.id);
         if (selectedNoteId.value === change.note.id) {
           selectedNoteId.value = null;
         }
@@ -95,6 +98,7 @@ export async function applyChanges(
           body,
           lastModified: change.note.lastModified,
         });
+        updateNoteLinks(change.note.id, body);
         break;
       }
     }

--- a/packages/app/src/ui/app.tsx
+++ b/packages/app/src/ui/app.tsx
@@ -41,6 +41,7 @@ import { saveSearchIndex } from "../search/search-persistence.ts";
 import { startWatcher } from "../storage/file-watcher.ts";
 import { loadFavorites } from "../favorites/favorite-persistence.ts";
 import { favoriteIds, initFavoritesCollapsed } from "../favorites/favorite-store.ts";
+import { buildBacklinkIndex, clearBacklinks } from "../notes/backlink-index.ts";
 import { startRouter, applyPendingHash } from "../lib/router.ts";
 import { Onboarding } from "./onboarding.tsx";
 import { RePermission } from "./re-permission.tsx";
@@ -110,6 +111,7 @@ async function openWithBackend(backend: StorageBackend): Promise<void> {
       appLoading.value = { phase: "indexing", loaded: i + 1, total: notes.length };
     }
     buildIndex(docs);
+    buildBacklinkIndex(docs);
     saveSearchIndex(serializeIndex()).catch(() => {});
   } catch (err) {
     // Index failure is non-fatal — notes are still usable
@@ -164,6 +166,7 @@ async function disconnectBackend(): Promise<void> {
   selectedNoteId.value = null;
   clearNotes();
   clearSearch();
+  clearBacklinks();
   favoriteIds.value = [];
   await clearBackendConfig();
   appView.value = "onboarding";

--- a/packages/app/src/ui/backlinks-section.module.css
+++ b/packages/app/src/ui/backlinks-section.module.css
@@ -1,0 +1,73 @@
+.backlinks {
+  border-top: 1px solid var(--color-border);
+  padding: 0.75rem 3rem 1.5rem;
+  margin-top: 2rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  transition: color 0.15s ease;
+}
+
+.header:hover {
+  color: var(--color-text);
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.headerIcon {
+  opacity: 0.6;
+}
+
+.chevron {
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+
+.list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+}
+
+.item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: none;
+  padding: 0.25rem 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  transition: color 0.15s ease;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.item:hover {
+  color: var(--color-accent);
+}
+
+/* ---- Mobile ---- */
+@media (max-width: 768px) {
+  .backlinks {
+    padding: 0.75rem 1rem 1.5rem;
+  }
+}

--- a/packages/app/src/ui/backlinks-section.module.css
+++ b/packages/app/src/ui/backlinks-section.module.css
@@ -44,13 +44,19 @@
   padding: 0;
 }
 
+.row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  min-width: 0;
+}
+
 .item {
-  display: block;
-  width: 100%;
   text-align: left;
   border: none;
   background: none;
-  padding: 0.25rem 0;
+  padding: 0;
   cursor: pointer;
   font-family: inherit;
   font-size: 0.8125rem;
@@ -59,10 +65,28 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex-shrink: 1;
+  min-width: 0;
 }
 
 .item:hover {
   color: var(--color-accent);
+}
+
+.tags {
+  display: flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.tag {
+  font-size: 0.625rem;
+  padding: 0.0625rem 0.375rem;
+  border-radius: 999px;
+  background: var(--color-tag-bg);
+  color: var(--color-tag-text);
+  font-weight: 500;
+  white-space: nowrap;
 }
 
 /* ---- Mobile ---- */

--- a/packages/app/src/ui/backlinks-section.tsx
+++ b/packages/app/src/ui/backlinks-section.tsx
@@ -43,7 +43,7 @@ export function BacklinksSection({ noteId }: { noteId: string }) {
       {!collapsed && (
         <ul class={styles.list}>
           {backlinks.map((note) => (
-            <li key={note.id}>
+            <li key={note.id} class={styles.row}>
               <button
                 class={styles.item}
                 onClick={() => {
@@ -53,6 +53,13 @@ export function BacklinksSection({ noteId }: { noteId: string }) {
               >
                 {note.title}
               </button>
+              {note.tags.length > 0 && (
+                <span class={styles.tags}>
+                  {note.tags.map((tag) => (
+                    <span key={tag} class={styles.tag}>{tag}</span>
+                  ))}
+                </span>
+              )}
             </li>
           ))}
         </ul>

--- a/packages/app/src/ui/backlinks-section.tsx
+++ b/packages/app/src/ui/backlinks-section.tsx
@@ -1,0 +1,62 @@
+import { useState } from "preact/hooks";
+import { selectedNoteId } from "../lib/app-state.ts";
+import { getBacklinks } from "../notes/backlink-index.ts";
+import { ChevronDown, ChevronRight, ArrowUpRight } from "lucide-preact";
+import styles from "./backlinks-section.module.css";
+
+/** Collapsed state persisted per-session (not per-note). */
+let sessionCollapsed = false;
+
+export function BacklinksSection({ noteId }: { noteId: string }) {
+  const backlinks = getBacklinks(noteId);
+
+  const [collapsed, setCollapsed] = useState(sessionCollapsed);
+
+  if (backlinks.length === 0) return null;
+
+  const toggle = () => {
+    const next = !collapsed;
+    sessionCollapsed = next;
+    setCollapsed(next);
+  };
+
+  return (
+    <div class={styles.backlinks}>
+      <button
+        class={styles.header}
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        aria-label={`${backlinks.length} backlinks, click to ${collapsed ? "expand" : "collapse"}`}
+      >
+        <span class={styles.headerLeft}>
+          <ArrowUpRight size={14} class={styles.headerIcon} />
+          <span>
+            {backlinks.length} {backlinks.length === 1 ? "backlink" : "backlinks"}
+          </span>
+        </span>
+        {collapsed ? (
+          <ChevronRight size={14} class={styles.chevron} />
+        ) : (
+          <ChevronDown size={14} class={styles.chevron} />
+        )}
+      </button>
+      {!collapsed && (
+        <ul class={styles.list}>
+          {backlinks.map((note) => (
+            <li key={note.id}>
+              <button
+                class={styles.item}
+                onClick={() => {
+                  selectedNoteId.value = note.id;
+                }}
+                title={note.title}
+              >
+                {note.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/ui/editor-view.module.css
+++ b/packages/app/src/ui/editor-view.module.css
@@ -242,25 +242,29 @@
   color: var(--color-accent);
 }
 
-.editorBody {
+.editorScroll {
   flex: 1;
   overflow-y: auto;
-  padding: 0 3rem;
   scrollbar-width: thin;
   scrollbar-color: var(--color-scrollbar) transparent;
 }
-.editorBody::-webkit-scrollbar {
+.editorScroll::-webkit-scrollbar {
   width: 6px;
 }
-.editorBody::-webkit-scrollbar-track {
+.editorScroll::-webkit-scrollbar-track {
   background: transparent;
 }
-.editorBody::-webkit-scrollbar-thumb {
+.editorScroll::-webkit-scrollbar-thumb {
   background: var(--color-scrollbar);
   border-radius: 3px;
 }
-.editorBody::-webkit-scrollbar-thumb:hover {
+.editorScroll::-webkit-scrollbar-thumb:hover {
   background: var(--color-scrollbar-hover);
+}
+
+.editorBody {
+  padding: 0 3rem;
+  min-height: 60vh;
 }
 
 
@@ -295,6 +299,7 @@
 
   .editorBody {
     padding: 0 1rem;
+    min-height: 50vh;
   }
 
   .statusBar {

--- a/packages/app/src/ui/editor-view.tsx
+++ b/packages/app/src/ui/editor-view.tsx
@@ -14,6 +14,8 @@ import { X, Paperclip, Star } from "lucide-preact";
 import type { Editor } from "@tiptap/core";
 import styles from "./editor-view.module.css";
 import { PropertyEditor } from "./property-editor.tsx";
+import { BacklinksSection } from "./backlinks-section.tsx";
+import { updateNoteLinks } from "../notes/backlink-index.ts";
 
 interface EditorViewProps {
   onDelete?: () => void;
@@ -95,6 +97,7 @@ export function EditorView_({ onDelete }: EditorViewProps) {
         body: bodyRef.current,
         lastModified: meta.lastModified,
       });
+      updateNoteLinks(note.id, bodyRef.current);
       saveStatus.value = "saved";
     } catch {
       saveStatus.value = "unsaved";
@@ -447,7 +450,10 @@ export function EditorView_({ onDelete }: EditorViewProps) {
           onTriggerAddHandled={() => setTriggerAddProperty(false)}
         />
       </div>
-      <div class={styles.editorBody} ref={containerRef} />
+      <div class={styles.editorScroll}>
+        <div class={styles.editorBody} ref={containerRef} />
+        <BacklinksSection noteId={note.id} />
+      </div>
       <div class={styles.statusBar}>
         <span>{wordCount.value} words</span>
         <span class={styles.saveIndicator}>


### PR DESCRIPTION
## Summary

This PR adds a backlinks feature to Thought.Haus that surfaces inbound connections between notes. Users can now see which other notes link to the current note, displayed as a collapsible section below the editor content.

## Key Changes

- **New backlink index module** (`packages/app/src/notes/backlink-index.ts`): A reactive, in-memory index that maps each note ID to the set of notes linking to it. Built during initial directory scan and updated incrementally on note save/delete.

- **Editor UI integration**: Added a backlinks section in `EditorView` that displays below the editor content, showing a count and clickable list of linking notes. The section only renders when backlinks exist, and can be toggled collapsed/expanded.

- **Integration with existing systems**: 
  - Backlink index is built during the initial scan alongside the search index
  - Updated on note save via `note-actions.ts`
  - Updated on note delete via `note-actions.ts`
  - Updated on external file changes via `file-watcher.ts`

- **Design philosophy**: Follows minimalist principles — no graph view, no unlinked mentions, no new panels or sidebars. Backlinks are ambient information displayed inline, not a primary interface.

## Implementation Details

- Uses existing `parseNoteLinks()` function to extract `[[noteId]]` references from note bodies
- Leverages Preact Signals for reactive updates, consistent with existing patterns (`notesMap`, `tagCounts`, etc.)
- Lightweight data structure (`Map<string, Set<string>>`) with negligible memory footprint
- Incremental updates on save are O(L) where L is the number of outgoing links in a note
- Handles edge cases: circular links, self-links, broken links, and deleted notes
- Mobile-responsive with no special treatment needed — inherits editor's responsive padding
- Styled consistently with existing metadata conventions using CSS modules

## What's Not Included

- Graph visualization (not planned)
- Unlinked mentions / fuzzy text matching (search already handles this)
- Backlink count badges in the notes list
- Outgoing links section (redundant with note content)
- Persistent backlink metadata files (computed at load time)

https://claude.ai/code/session_01MxbxEkBhNyfhU3jp6x6KcL