### PR TITLE
Improve tag input focus and selection behavior

### DIFF
--- a/packages/app/src/ui/editor-view.tsx
+++ b/packages/app/src/ui/editor-view.tsx
@@ -26,6 +26,8 @@ export function EditorView_({ onDelete }: EditorViewProps) {
   const noteIdRef = useRef<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const titleInputRef = useRef<HTMLInputElement>(null);
+  const tagInputRef = useRef<HTMLInputElement>(null);
+  const tagEscapeRef = useRef(false);
   const [tagInput, setTagInput] = useState("");
   const [showTagInput, setShowTagInput] = useState(false);
   const [tagHighlight, setTagHighlight] = useState(-1);
@@ -201,7 +203,6 @@ export function EditorView_({ onDelete }: EditorViewProps) {
 
       upsertNote({ ...note, tags: [...note.tags, tag] });
       setTagInput("");
-      setShowTagInput(false);
       setTagHighlight(-1);
       saveNote();
     },
@@ -248,6 +249,13 @@ export function EditorView_({ onDelete }: EditorViewProps) {
   }, [titleDraft]);
 
   // handleTagKeyDown is defined inline in JSX to capture tagSuggestions from render scope
+
+  // Focus tag input when it becomes visible
+  useEffect(() => {
+    if (showTagInput) {
+      tagInputRef.current?.focus();
+    }
+  }, [showTagInput]);
 
   // Cmd/Ctrl+; to add property
   useEffect(() => {
@@ -367,12 +375,12 @@ export function EditorView_({ onDelete }: EditorViewProps) {
             {showTagInput ? (
               <div class={styles.tagInputWrapper}>
                 <input
+                  ref={tagInputRef}
                   class={styles.tagInput}
                   type="text"
                   value={tagInput}
                   placeholder="tag name"
                   aria-label="Add tag"
-                  autoFocus
                   onInput={(e) => {
                     setTagInput((e.target as HTMLInputElement).value);
                     setTagHighlight(-1);
@@ -383,7 +391,10 @@ export function EditorView_({ onDelete }: EditorViewProps) {
                         items: tagSuggestions,
                         highlightedIndex: tagHighlight,
                         onHighlightChange: setTagHighlight,
-                        onSelect: (item) => addTag(item.label),
+                        onSelect: (item) => {
+                          addTag(item.label);
+                          tagInputRef.current?.focus();
+                        },
                       });
                       if (consumed) {
                         e.preventDefault();
@@ -393,18 +404,23 @@ export function EditorView_({ onDelete }: EditorViewProps) {
                     if (e.key === "Enter") {
                       e.preventDefault();
                       addTag((e.target as HTMLInputElement).value);
+                      // Input stays focused for the next tag
                     } else if (e.key === "Escape") {
+                      tagEscapeRef.current = true;
                       setTagInput("");
                       setShowTagInput(false);
                       setTagHighlight(-1);
                     }
                   }}
                   onBlur={() => {
+                    if (tagEscapeRef.current) {
+                      tagEscapeRef.current = false;
+                      return;
+                    }
                     if (tagInput.trim()) {
                       addTag(tagInput);
-                    } else {
-                      setShowTagInput(false);
                     }
+                    setShowTagInput(false);
                   }}
                 />
                 <InlineAutocomplete


### PR DESCRIPTION
## Summary
Refactored the tag input component to improve focus management and user experience when adding multiple tags in sequence.

## Key Changes
- Replaced `autoFocus` attribute with a `useEffect` hook that focuses the tag input when `showTagInput` becomes true, providing more reliable focus management
- Added `tagEscapeRef` to track when Escape key is pressed, preventing the input from closing when the user intends to continue adding tags
- Modified `addTag()` to no longer close the tag input after adding a tag, allowing users to add multiple tags without the UI collapsing
- Updated the `onBlur` handler to:
  - Respect the Escape key flag to avoid closing the input unintentionally
  - Always close the input after blur (whether a tag was added or not)
- Added focus restoration in the autocomplete `onSelect` callback to keep focus on the input after selecting a suggestion
- Removed the `setShowTagInput(false)` call from `addTag()` to keep the input visible for continuous tag entry

## Implementation Details
- The `tagEscapeRef` flag is set when Escape is pressed and cleared in the `onBlur` handler, allowing the blur event to skip closing the input when escape was the trigger
- The input now stays focused after adding a tag via Enter key or autocomplete selection, enabling a smoother workflow for adding multiple tags
- Focus is managed declaratively through `useEffect` rather than the imperative `autoFocus` attribute, which is more reliable in React

https://claude.ai/code/session_0173To4yy3gX68NAcYEiZD4Y